### PR TITLE
Use the input.ref in the macos build

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -95,7 +95,7 @@ jobs:
         with:
           submodules: true
           repository: anoma/juvix
-          ref: main
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |


### PR DESCRIPTION
https://github.com/anoma/juvix-nightly-builds/pull/2 introduced a input parameter so that the linux nightly build can be triggered from a anoma/juvix ref other than main. This PR uses this ref for the macos build too.