### PR TITLE
Add git checkout permissions workaround

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -39,6 +39,11 @@ jobs:
       - name: Stack permissions bug workaround
         run: "chown -R $(id -un):$(id -gn) ~"
 
+      # Without this the git command used by githash TemplateHaskell fails with permission error
+      # https://github.com/anoma/juvix/issues/2294
+      - name: Git permissions workaround
+        run: "chown -R $(id -un):$(id -gn) ."
+
       - name: Install clang14
         run: apk add --update clang14
 


### PR DESCRIPTION
When obtaining build-time git information the git command fails with a permissions error in the container. This step fixes this issue