### PR TITLE
Fix release-nightly workflow

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -11,7 +11,7 @@ jobs:
   build-linux:
     name: Build static Linux binary and release
     runs-on: ubuntu-latest
-    container: glcr.b-data.ch/ghc/ghc-musl:9.4.5
+    container: quay.io/benz0li/ghc-musl:9.8.1
     outputs:
       tag: ${{ steps.tag.outputs.value }}
     steps:
@@ -44,11 +44,14 @@ jobs:
       - name: Git permissions workaround
         run: "chown -R $(id -un):$(id -gn) ."
 
-      - name: Install clang14
-        run: apk add --update clang14
+      - name: Install clang
+        run: apk add --update clang
+
+      - name: Install llvm
+        run: apk add --update llvm
 
       - name: Runtime build
-        run: make runtime LIBTOOL=llvm14-ar
+        run: make runtime LIBTOOL=llvm-ar
 
       - name: build Juvix
         run: stack install --allow-different-user --system-ghc --ghc-options='-split-sections' --flag juvix:static


### PR DESCRIPTION
* The Juvix project now builds with GHC 9.8.1

* The alpine abstract packages clang/llvm now meet minimum version requirements.

* The llvm package must now be installed separately to get the `llvm-ar` tool.